### PR TITLE
Update text color on action-message.blade.php

### DIFF
--- a/resources/views/components/action-message.blade.php
+++ b/resources/views/components/action-message.blade.php
@@ -8,7 +8,7 @@
     x-show.transition.out.opacity.duration.1500ms="shown"
     x-transition:leave.opacity.duration.1500ms
     style="display: none"
-    {{ $attributes->merge(['class' => 'text-sm text-gray-600']) }}
+    {{ $attributes->merge(['class' => 'text-sm']) }}
 >
     {{ $slot->isEmpty() ? __('Saved.') : $slot }}
 </div>


### PR DESCRIPTION
fix "Saved" text color on action-message.blade.php component

before
![Screenshot 2025-02-25 at 03 09 57 (2)](https://github.com/user-attachments/assets/8e5ab613-7762-4cb3-98d5-83c47adb2a81)
![Screenshot 2025-02-25 at 03 13 17 (2)](https://github.com/user-attachments/assets/99257758-8b5c-448c-8103-ebe7f99a7367)


after
![Screenshot 2025-02-25 at 03 10 11 (2)](https://github.com/user-attachments/assets/dc839c72-1ef6-4178-ac20-66c842e9948c)
![Screenshot 2025-02-25 at 03 15 23 (2)](https://github.com/user-attachments/assets/4a6417d5-8dd7-4519-9e36-6e88ac85d8ce)
