### PR TITLE
Added wire:current to navigation items

### DIFF
--- a/resources/views/components/settings/layout.blade.php
+++ b/resources/views/components/settings/layout.blade.php
@@ -1,9 +1,9 @@
 <div class="flex items-start max-md:flex-col">
     <div class="mr-10 w-full pb-4 md:w-[220px]">
         <flux:navlist>
-            <flux:navlist.item href="{{ route('settings.profile') }}" wire:navigate>Profile</flux:navlist.item>
-            <flux:navlist.item href="{{ route('settings.password') }}" wire:navigate>Password</flux:navlist.item>
-            <flux:navlist.item href="{{ route('settings.appearance') }}" wire:navigate>Appearance</flux:navlist.item>
+            <flux:navlist.item href="{{ route('settings.profile') }}" wire:navigate wire:current>Profile</flux:navlist.item>
+            <flux:navlist.item href="{{ route('settings.password') }}" wire:navigate wire:current>Password</flux:navlist.item>
+            <flux:navlist.item href="{{ route('settings.appearance') }}" wire:navigate wire:current>Appearance</flux:navlist.item>
         </flux:navlist>
     </div>
 


### PR DESCRIPTION
As shown in the first image, when entering a route, the configuration menu item is not checked, so when adding wire:current it adds the "Current" class of the flux component as shown in image two.

According to the Flux documentation itself
https://fluxui.dev/layouts/header

Here is an example of the profile item

Image One
<img width="1158" alt="Captura de Tela 2025-02-24 às 18 54 26" src="https://github.com/user-attachments/assets/11d83ac8-cccd-446d-8c18-a94ef0bf872f" />

Image Two
<img width="1178" alt="Captura de Tela 2025-02-24 às 18 58 09" src="https://github.com/user-attachments/assets/2d39bbc7-f9e0-464a-9788-49f9e18e3be3" />
