### PR TITLE
Added viewable attribute to password components

### DIFF
--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -92,6 +92,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
                 required
                 autocomplete="current-password"
                 placeholder="Password"
+                viewable
             />
 
             @if (Route::has('password.request'))

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -63,6 +63,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
                 required
                 autocomplete="new-password"
                 placeholder="Password"
+                viewable
             />
         </div>
 
@@ -77,6 +78,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
                 required
                 autocomplete="new-password"
                 placeholder="Confirm password"
+                viewable
             />
         </div>
 


### PR DESCRIPTION
The login and registration forms have password input fields, but do not show the possibility to view the password, so the viewable attribute was added to the password components of the login and registration form.