### PR TITLE
fix pattern overflow on placeholder

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -11,7 +11,7 @@
                 <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
             </div>
         </div>
-        <div class="relative h-full flex-1 rounded-xl border border-neutral-200 dark:border-neutral-700">
+        <div class="relative h-full flex-1 overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
             <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
         </div>
     </div>


### PR DESCRIPTION
Minor tweak to hide overflowing pattern through the border.

**Before**
<img width="466" alt="image" src="https://github.com/user-attachments/assets/9fb5905e-a810-43c2-b2da-75fe0d5eb0b9" />

**After**
<img width="365" alt="image" src="https://github.com/user-attachments/assets/5c39835f-01c0-42b4-b7b9-1b6ed4a6a1d7" />

Love your work!

👌