### PR TITLE
Fix styles for update profile & verify email with dark mode

### DIFF
--- a/resources/views/livewire/auth/verify-email.blade.php
+++ b/resources/views/livewire/auth/verify-email.blade.php
@@ -35,7 +35,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 }; ?>
 
 <div class="mt-4 flex flex-col gap-6">
-    <div class="text-center text-sm text-gray-600">
+    <div class="text-center text-sm text-zinc-500 dark:text-white/70">
         {{ __('Please verify your email address by clicking on the link we just emailed to you.') }}
     </div>
 
@@ -53,7 +53,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <button
             wire:click="logout"
             type="submit"
-            class="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            class="underline text-sm decoration-neutral-400 underline-offset-2 duration-300 ease-out hover:decoration-neutral-700 text-neutral-900 dark:text-neutral-200 dark:hover:decoration-neutral-100"
         >
             {{ __('Log out') }}
         </button>

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -81,12 +81,12 @@ new class extends Component {
 
                 @if (auth()->user() instanceof \Illuminate\Contracts\Auth\MustVerifyEmail &&! auth()->user()->hasVerifiedEmail())
                     <div>
-                        <p class="mt-2 text-sm text-gray-800">
+                        <p class="mt-2 text-sm text-zinc-500 dark:text-white/70">
                             {{ __('Your email address is unverified.') }}
 
                             <button
                                 wire:click.prevent="resendVerificationNotification"
-                                class="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                class="underline text-sm decoration-neutral-400 underline-offset-2 duration-300 ease-out hover:decoration-neutral-700 text-neutral-900 dark:text-neutral-200 dark:hover:decoration-neutral-100"
                             >
                                 {{ __('Click here to re-send the verification email.') }}
                             </button>


### PR DESCRIPTION
# Fix styles for update profile with darkmode

Resolved incorrect styles in dark mode while settings/profile worked fine in light mode.
Resolved incorrect styles in dark mode while verify-email worked fine in light mode.

![problem](https://github.com/user-attachments/assets/f7d2753f-bb96-4cdb-b79d-e001c44613b8)
![livewire-verify-email](https://github.com/user-attachments/assets/0ae662cb-5bcd-4ead-8fe8-e48a536e6ccf)

## The fix

![correction](https://github.com/user-attachments/assets/d2f669c8-16b1-4213-8bf4-bc723ebb8b0b)
![correct-livewire](https://github.com/user-attachments/assets/a34be90c-0ee6-4198-8423-f68dda88a2bc)

