### PR TITLE
Using `flux:link` component instead of custom `text-link` blade component

### DIFF
--- a/resources/views/components/text-link.blade.php
+++ b/resources/views/components/text-link.blade.php
@@ -1,6 +1,0 @@
-<a
-    {{ $attributes->merge(['class' => 'underline text-sm decoration-neutral-400 underline-offset-2 duration-300 ease-out hover:decoration-neutral-700 text-neutral-900 dark:text-neutral-200 dark:hover:decoration-neutral-100']) }}
-    wire:navigate
->
-    {{ $slot }}
-</a>

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -45,6 +45,6 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
     <div class="space-x-1 text-center text-sm text-zinc-400">
         Or, return to
-        <x-text-link href="{{ route('login') }}">log in</x-text-link>
+        <flux:link href="{{ route('login') }}" wire:navigate>log in</flux:link>
     </div>
 </div>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -104,9 +104,9 @@ new #[Layout('components.layouts.auth')] class extends Component {
             />
 
             @if (Route::has('password.request'))
-                <x-text-link class="absolute right-0 top-0" href="{{ route('password.request') }}">
+                <flux:link class="absolute right-0 top-0 text-sm" href="{{ route('password.request') }}" wire:navigate>
                     {{ __('Forgot your password?') }}
-                </x-text-link>
+                </flux:link>
             @endif
         </div>
 
@@ -120,6 +120,6 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
     <div class="space-x-1 text-center text-sm text-zinc-600 dark:text-zinc-400">
         Don't have an account?
-        <x-text-link href="{{ route('register') }}">Sign up</x-text-link>
+        <flux:link href="{{ route('register') }}" wire:navigate>Sign up</flux:link>
     </div>
 </div>

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -100,6 +100,6 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
     <div class="space-x-1 text-center text-sm text-zinc-600 dark:text-zinc-400">
         Already have an account?
-        <x-text-link href="{{ route('login') }}">Log in</x-text-link>
+        <flux:link href="{{ route('login') }}" wire:navigate>Log in</flux:link>
     </div>
 </div>


### PR DESCRIPTION
This removes the custom `x-text-link` blade component in favor of using the **free** `flux:link` component.
And therefore removes unnecessary complexity.