### PR TITLE
Changed standard HTML tags with flux tags

### DIFF
--- a/resources/views/components/auth-header.blade.php
+++ b/resources/views/components/auth-header.blade.php
@@ -3,7 +3,7 @@
     'description',
 ])
 
-<div class="flex w-full flex-col gap-2 text-center">
+<div class="flex w-full flex-col text-center">
     <flux:heading size="xl">{{ $title }}</flux:heading>
     <flux:subheading>{{ $description }}</flux:subheading>
 </div>

--- a/resources/views/components/auth-header.blade.php
+++ b/resources/views/components/auth-header.blade.php
@@ -4,6 +4,6 @@
 ])
 
 <div class="flex w-full flex-col gap-2 text-center">
-    <h1 class="text-xl font-medium dark:text-zinc-200">{{ $title }}</h1>
-    <p class="text-center text-sm dark:text-zinc-400">{{ $description }}</p>
+    <flux:heading size="lg">{{ $title }}</flux:heading>
+    <flux:subheading>{{ $description }}</flux:subheading>
 </div>

--- a/resources/views/components/auth-header.blade.php
+++ b/resources/views/components/auth-header.blade.php
@@ -4,6 +4,6 @@
 ])
 
 <div class="flex w-full flex-col gap-2 text-center">
-    <flux:heading size="lg">{{ $title }}</flux:heading>
+    <flux:heading size="xl">{{ $title }}</flux:heading>
     <flux:subheading>{{ $description }}</flux:subheading>
 </div>

--- a/resources/views/components/layouts/auth/split.blade.php
+++ b/resources/views/components/layouts/auth/split.blade.php
@@ -20,8 +20,8 @@
 
                 <div class="relative z-20 mt-auto">
                     <blockquote class="space-y-2">
-                        <flux:text size="xl">&ldquo;{{ trim($message) }}&rdquo;</flux:text>
-                        <footer><flux:text>{{ trim($author) }}</flux:text></footer>
+                        <flux:heading size="lg">&ldquo;{{ trim($message) }}&rdquo;</flux:heading>
+                        <footer><flux:heading>{{ trim($author) }}</flux:heading></footer>
                     </blockquote>
                 </div>
             </div>

--- a/resources/views/components/layouts/auth/split.blade.php
+++ b/resources/views/components/layouts/auth/split.blade.php
@@ -20,8 +20,8 @@
 
                 <div class="relative z-20 mt-auto">
                     <blockquote class="space-y-2">
-                        <p class="text-lg">&ldquo;{{ trim($message) }}&rdquo;</p>
-                        <footer class="text-sm">{{ trim($author) }}</footer>
+                        <flux:text size="xl">&ldquo;{{ trim($message) }}&rdquo;</flux:text>
+                        <footer><flux:text>{{ trim($author) }}</flux:text></footer>
                     </blockquote>
                 </div>
             </div>

--- a/resources/views/livewire/auth/verify-email.blade.php
+++ b/resources/views/livewire/auth/verify-email.blade.php
@@ -40,7 +40,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     </flux:text>
 
     @if (session('status') == 'verification-link-sent')
-        <flux:text class="text-center !dark:text-green-400 !text-green-600">
+        <flux:text class="text-center font-medium !dark:text-green-400 !text-green-600">
             {{ __('A new verification link has been sent to the email address you provided during registration.') }}
         </flux:text>
     @endif

--- a/resources/views/livewire/auth/verify-email.blade.php
+++ b/resources/views/livewire/auth/verify-email.blade.php
@@ -35,14 +35,14 @@ new #[Layout('components.layouts.auth')] class extends Component {
 }; ?>
 
 <div class="mt-4 flex flex-col gap-6">
-    <div class="text-center text-sm text-gray-600">
+    <flux:text class="text-center">
         {{ __('Please verify your email address by clicking on the link we just emailed to you.') }}
-    </div>
+    </flux:text>
 
     @if (session('status') == 'verification-link-sent')
-        <div class="font-medium text-center text-sm text-green-600">
+        <flux:text class="text-center !dark:text-green-400 !text-green-600">
             {{ __('A new verification link has been sent to the email address you provided during registration.') }}
-        </div>
+        </flux:text>
     @endif
 
     <div class="flex flex-col items-center justify-between space-y-3">

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -93,7 +93,7 @@ new class extends Component {
                         </flux:text>
 
                         @if (session('status') === 'verification-link-sent')
-                            <flux:text class="mt-2 !dark:text-green-400 !text-green-600">
+                            <flux:text class="mt-2 font-medium !dark:text-green-400 !text-green-600">
                                 {{ __('A new verification link has been sent to your email address.') }}
                             </flux:text>
                         @endif

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -81,7 +81,7 @@ new class extends Component {
 
                 @if (auth()->user() instanceof \Illuminate\Contracts\Auth\MustVerifyEmail &&! auth()->user()->hasVerifiedEmail())
                     <div>
-                        <flux:text class="mt-2">
+                        <flux:text class="mt-4">
                             {{ __('Your email address is unverified.') }}
 
                             <button

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -81,7 +81,7 @@ new class extends Component {
 
                 @if (auth()->user() instanceof \Illuminate\Contracts\Auth\MustVerifyEmail &&! auth()->user()->hasVerifiedEmail())
                     <div>
-                        <p class="mt-2 text-sm text-gray-800">
+                        <flux:text class="mt-2">
                             {{ __('Your email address is unverified.') }}
 
                             <button
@@ -90,12 +90,12 @@ new class extends Component {
                             >
                                 {{ __('Click here to re-send the verification email.') }}
                             </button>
-                        </p>
+                        </flux:text>
 
                         @if (session('status') === 'verification-link-sent')
-                            <p class="mt-2 text-sm font-medium text-green-600">
+                            <flux:text class="mt-2 !dark:text-green-400 !text-green-600">
                                 {{ __('A new verification link has been sent to your email address.') }}
-                            </p>
+                            </flux:text>
                         @endif
                     </div>
                 @endif


### PR DESCRIPTION
This PR changes default HTML tags to flux tags like; `flux:heading` `flux:subheading` `flux:text`

This fixes issues with themes and dark mode, and keeps the whole website consistent!
We should avoid using default paragraph and heading tags with TailwindCSS calasses on them, as much as possible to not break themes and darkmode.