### PR TITLE
Add missing translation method

### DIFF
--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -34,8 +34,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
 <div class="flex flex-col gap-6">
     <x-auth-header
-        title="Confirm password"
-        description="This is a secure area of the application. Please confirm your password before continuing."
+        title="{{ __('Confirm password') }}"
+        description="{{ __('This is a secure area of the application. Please confirm your password before continuing.') }}"
     />
 
     <!-- Session Status -->

--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -34,8 +34,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
 <div class="flex flex-col gap-6">
     <x-auth-header
-        title="{{ __('Confirm password') }}"
-        description="{{ __('This is a secure area of the application. Please confirm your password before continuing.') }}"
+        :title="__('Confirm password')"
+        :description="__('This is a secure area of the application. Please confirm your password before continuing.')"
     />
 
     <!-- Session Status -->
@@ -46,7 +46,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <flux:input
             wire:model="password"
             id="password"
-            label="{{ __('Password') }}"
+            :label="__('Password')"
             type="password"
             name="password"
             required

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -23,7 +23,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-6">
-    <x-auth-header title="Forgot password" description="Enter your email to receive a password reset link" />
+    <x-auth-header title="{{ __('Forgot password') }}" description="{{ __('Enter your email to receive a password reset link') }}" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -44,7 +44,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     </form>
 
     <div class="space-x-1 text-center text-sm text-zinc-400">
-        Or, return to
-        <x-text-link href="{{ route('login') }}">log in</x-text-link>
+    {{ __('Or, return to') }}
+    <flux:link href="{{ route('login') }}" wire:navigate>{{ __('log in') }}</flux:link>
     </div>
 </div>

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -23,7 +23,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-6">
-    <x-auth-header title="{{ __('Forgot password') }}" description="{{ __('Enter your email to receive a password reset link') }}" />
+    <x-auth-header :title="__('Forgot password')" :description="__('Enter your email to receive a password reset link')" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -32,7 +32,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <!-- Email Address -->
         <flux:input
             wire:model="email"
-            label="{{ __('Email Address') }}"
+            :label="__('Email Address')"
             type="email"
             name="email"
             required

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -73,7 +73,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-6">
-    <x-auth-header title="{{ __('Log in to your account') }}" description="{{ __('Enter your email and password below to log in') }}" />
+    <x-auth-header :title="__('Log in to your account')" :description="__('Enter your email and password below to log in')" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -82,7 +82,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <!-- Email Address -->
         <flux:input
             wire:model="email"
-            label="{{ __('Email address') }}"
+            :label="__('Email address')"
             type="email"
             name="email"
             required
@@ -95,7 +95,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <div class="relative">
             <flux:input
                 wire:model="password"
-                label="{{ __('Password') }}"
+                :label="__('Password')"
                 type="password"
                 name="password"
                 required
@@ -111,7 +111,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         </div>
 
         <!-- Remember Me -->
-        <flux:checkbox wire:model="remember" label="{{ __('Remember me') }}" />
+        <flux:checkbox wire:model="remember" :label="__('Remember me')" />
 
         <div class="flex items-center justify-end">
             <flux:button variant="primary" type="submit" class="w-full">{{ __('Log in') }}</flux:button>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -73,7 +73,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-6">
-    <x-auth-header title="Log in to your account" description="Enter your email and password below to log in" />
+    <x-auth-header title="{{ __('Log in to your account') }}" description="{{ __('Enter your email and password below to log in') }}" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -104,9 +104,9 @@ new #[Layout('components.layouts.auth')] class extends Component {
             />
 
             @if (Route::has('password.request'))
-                <x-text-link class="absolute right-0 top-0" href="{{ route('password.request') }}">
+                <flux:link class="absolute right-0 top-0 text-sm" href="{{ route('password.request') }}" wire:navigate>
                     {{ __('Forgot your password?') }}
-                </x-text-link>
+                </flux:link>
             @endif
         </div>
 
@@ -119,7 +119,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     </form>
 
     <div class="space-x-1 text-center text-sm text-zinc-600 dark:text-zinc-400">
-        Don't have an account?
-        <x-text-link href="{{ route('register') }}">Sign up</x-text-link>
+    {{ __('Don\'t have an account?') }}
+        <flux:link href="{{ route('register') }}" wire:navigate>{{ __('Sign up') }}</flux:link>
     </div>
 </div>

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -36,7 +36,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-6">
-    <x-auth-header title="{{ __('Create an account') }}" description="{{ __('Enter your details below to create your account') }}" />
+    <x-auth-header :title="__('Create an account')" :description="__('Enter your details below to create your account')" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -46,7 +46,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <flux:input
             wire:model="name"
             id="name"
-            label="{{ __('Name') }}"
+            :label="__('Name')"
             type="text"
             name="name"
             required
@@ -59,7 +59,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <flux:input
             wire:model="email"
             id="email"
-            label="{{ __('Email address') }}"
+            :label="__('Email address')"
             type="email"
             name="email"
             required
@@ -71,7 +71,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <flux:input
             wire:model="password"
             id="password"
-            label="{{ __('Password') }}"
+            :label="__('Password')"
             type="password"
             name="password"
             required
@@ -83,7 +83,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <flux:input
             wire:model="password_confirmation"
             id="password_confirmation"
-            label="{{ __('Confirm password') }}"
+            :label="__('Confirm password')"
             type="password"
             name="password_confirmation"
             required

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -36,7 +36,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-6">
-    <x-auth-header title="Create an account" description="Enter your details below to create your account" />
+    <x-auth-header title="{{ __('Create an account') }}" description="{{ __('Enter your details below to create your account') }}" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -99,7 +99,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     </form>
 
     <div class="space-x-1 text-center text-sm text-zinc-600 dark:text-zinc-400">
-        Already have an account?
-        <x-text-link href="{{ route('login') }}">Log in</x-text-link>
+    {{ __('Already have an account?') }}
+        <flux:link href="{{ route('login') }}" wire:navigate>{{ __('Log in') }}</flux:link>
     </div>
 </div>

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -69,7 +69,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-6">
-    <x-auth-header title="{{ __('Reset password') }}" description="{{ __('Please enter your new password below') }}" />
+    <x-auth-header :title="__('Reset password')" :description="__('Please enter your new password below')" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -79,7 +79,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <flux:input
             wire:model="email"
             id="email"
-            label="{{ __('Email') }}"
+            :label="__('Email')"
             type="email"
             name="email"
             required
@@ -90,7 +90,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <flux:input
             wire:model="password"
             id="password"
-            label="{{ __('Password') }}"
+            :label="__('Password')"
             type="password"
             name="password"
             required
@@ -102,7 +102,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <flux:input
             wire:model="password_confirmation"
             id="password_confirmation"
-            label="{{ __('Confirm password') }}"
+            :label="__('Confirm password')"
             type="password"
             name="password_confirmation"
             required

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -69,7 +69,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-6">
-    <x-auth-header title="Reset password" description="Please enter your new password below" />
+    <x-auth-header title="{{ __('Reset password') }}" description="{{ __('Please enter your new password below') }}" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />

--- a/resources/views/livewire/settings/appearance.blade.php
+++ b/resources/views/livewire/settings/appearance.blade.php
@@ -9,7 +9,7 @@ new class extends Component {
 <div class="flex flex-col items-start">
     @include('partials.settings-heading')
 
-    <x-settings.layout heading="{{ __('Appearance') }}" subheading="{{ __('Update the appearance settings for your account') }}">
+    <x-settings.layout :heading="__('Appearance')" :subheading="__('Update the appearance settings for your account')">
         <flux:radio.group x-data variant="segmented" x-model="$flux.appearance">
             <flux:radio value="light" icon="sun">{{ __('Light') }}</flux:radio>
             <flux:radio value="dark" icon="moon">{{ __('Dark') }}</flux:radio>

--- a/resources/views/livewire/settings/delete-user-form.blade.php
+++ b/resources/views/livewire/settings/delete-user-form.blade.php
@@ -44,7 +44,7 @@ new class extends Component {
                 </flux:subheading>
             </div>
 
-            <flux:input wire:model="password" id="password" label="{{ __('Password') }}" type="password" name="password" />
+            <flux:input wire:model="password" id="password" :label="__('Password')" type="password" name="password" />
 
             <div class="flex justify-end space-x-2">
                 <flux:modal.close>

--- a/resources/views/livewire/settings/password.blade.php
+++ b/resources/views/livewire/settings/password.blade.php
@@ -40,12 +40,12 @@ new class extends Component {
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <x-settings.layout heading="{{ __('Update password') }}" subheading="{{ __('Ensure your account is using a long, random password to stay secure') }}">
+    <x-settings.layout :heading="__('Update password')" :subheading="__('Ensure your account is using a long, random password to stay secure')">
         <form wire:submit="updatePassword" class="mt-6 space-y-6">
             <flux:input
                 wire:model="current_password"
                 id="update_password_current_passwordpassword"
-                label="{{ __('Current password') }}"
+                :label="__('Current password')"
                 type="password"
                 name="current_password"
                 required
@@ -54,7 +54,7 @@ new class extends Component {
             <flux:input
                 wire:model="password"
                 id="update_password_password"
-                label="{{ __('New password') }}"
+                :label="__('New password')"
                 type="password"
                 name="password"
                 required
@@ -63,7 +63,7 @@ new class extends Component {
             <flux:input
                 wire:model="password_confirmation"
                 id="update_password_password_confirmation"
-                label="{{ __('Confirm Password') }}"
+                :label="__('Confirm Password')"
                 type="password"
                 name="password_confirmation"
                 required

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -72,12 +72,12 @@ new class extends Component {
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <x-settings.layout heading="{{ __('Profile') }}" subheading="{{ __('Update your name and email address') }}">
+    <x-settings.layout :heading="__('Profile')" :subheading="__('Update your name and email address')">
         <form wire:submit="updateProfileInformation" class="my-6 w-full space-y-6">
-            <flux:input wire:model="name" label="{{ __('Name') }}" type="text" name="name" required autofocus autocomplete="name" />
+        <flux:input wire:model="name" :label="__('Name')" type="text" name="name" required autofocus autocomplete="name" />
 
             <div>
-                <flux:input wire:model="email" label="{{ __('Email') }}" type="email" name="email" required autocomplete="email" />
+                <flux:input wire:model="email" :label="__('Email')" type="email" name="email" required autocomplete="email" />
 
                 @if (auth()->user() instanceof \Illuminate\Contracts\Auth\MustVerifyEmail &&! auth()->user()->hasVerifiedEmail())
                     <div>


### PR DESCRIPTION
## What's this?

After PR https://github.com/laravel/livewire-starter-kit/pull/24 was merged, I noticed some parts were still missing the translation method. This fix addresses those remaining issues to ensure all parts are covered.