### PR TITLE
fix: run pest instead of phpunit to fix failing ci action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,4 +51,4 @@ jobs:
         run: npm run build
 
       - name: Run Tests
-        run: ./vendor/bin/phpunit
+        run: ./vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,4 +51,4 @@ jobs:
         run: npm run build
 
       - name: Run Tests
-        run: ./vendor/bin/pest
+        run: php artisan test


### PR DESCRIPTION
When pushing the starter kit to Github, the ci test fails due to running phpunit instead of pest. This PR is just addressing that :) 

Before
![ci failure](https://github.com/user-attachments/assets/75e344e0-171e-4105-b5ec-c326bc1dd479)

After
![ci fixed](https://github.com/user-attachments/assets/4dbcec49-0738-4aad-af8d-9ebe5474cc28)
