### PR TITLE
Changed default button tags to be `flux:link` tags

### DIFF
--- a/resources/views/livewire/auth/verify-email.blade.php
+++ b/resources/views/livewire/auth/verify-email.blade.php
@@ -50,12 +50,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
             {{ __('Resend verification email') }}
         </flux:button>
 
-        <button
-            wire:click="logout"
-            type="submit"
-            class="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-        >
+        <flux:link class="text-sm cursor-pointer" wire:click="logout">
             {{ __('Log out') }}
-        </button>
+        </flux:link>
     </div>
 </div>

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -84,12 +84,9 @@ new class extends Component {
                         <p class="mt-2 text-sm text-gray-800">
                             {{ __('Your email address is unverified.') }}
 
-                            <button
-                                wire:click.prevent="resendVerificationNotification"
-                                class="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                            >
+                            <flux:link class="text-sm cursor-pointer" wire:click.prevent="resendVerificationNotification">
                                 {{ __('Click here to re-send the verification email.') }}
-                            </button>
+                            </flux:link>
                         </p>
 
                         @if (session('status') === 'verification-link-sent')


### PR DESCRIPTION
This PR changes default HTML button tags that looks like links to `flux:link` without a href attribute.

Also added hover effect to change the cursor to pointer.
Because we don't have a href attribute but a `wire:click` attribute, this link acts like a button instead of a link, but looks like a link.

Refrences;
Dark and light mode, the top "log out" button is the new one.
![Screenshot From 2025-02-26 10-35-22](https://github.com/user-attachments/assets/24dbcac6-9166-4700-b2ff-47bb698a8223)
![Screenshot From 2025-02-26 10-35-39](https://github.com/user-attachments/assets/4e24270a-ef9d-4bf5-bf50-c0744237c863)
Before:
![Screenshot From 2025-02-26 10-36-52](https://github.com/user-attachments/assets/f16149aa-12e7-4d37-a2f5-cbc1a597e016)
![Screenshot From 2025-02-26 10-37-13](https://github.com/user-attachments/assets/97033e83-e005-42ae-9a6c-7bb859cd5deb)
After:
![Screenshot From 2025-02-26 10-37-01](https://github.com/user-attachments/assets/be0b75bd-3429-462c-a867-eb249cd94e3d)
![Screenshot From 2025-02-26 10-37-22](https://github.com/user-attachments/assets/c16b2df6-57b9-4984-a521-32da45ee797c)
