### PR TITLE
Remove unnecessary SQLite file creation in test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Install Node Dependencies
         run: npm i
 
-      - name: Create SQLite Database
-        run: touch database/database.sqlite
-
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 


### PR DESCRIPTION
In the test workflow (tests.yml), SQLite file creation is included.
However, since `phpunit.xml` configures SQLite to run **in memory** during test execution, SQLite file is not needed in the test CI.

https://github.com/laravel/livewire-starter-kit/blob/a2d6925fdc015ea1ed4b1e13097d842fda4ded93/phpunit.xml#L25-L26

I’ve also submitted same PRs for the Vue and React starter kits:
Vue: https://github.com/laravel/vue-starter-kit/pull/56
React: https://github.com/laravel/react-starter-kit/pull/52
