### PR TITLE
Add check for register route in case registrations have been disabled

### DIFF
--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -117,9 +117,10 @@ new #[Layout('components.layouts.auth')] class extends Component {
             <flux:button variant="primary" type="submit" class="w-full">{{ __('Log in') }}</flux:button>
         </div>
     </form>
-
+@if (Route::has('register'))
     <div class="space-x-1 text-center text-sm text-zinc-600 dark:text-zinc-400">
         Don't have an account?
         <flux:link href="{{ route('register') }}" wire:navigate>Sign up</flux:link>
     </div>
+@endif
 </div>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -117,10 +117,10 @@ new #[Layout('components.layouts.auth')] class extends Component {
             <flux:button variant="primary" type="submit" class="w-full">{{ __('Log in') }}</flux:button>
         </div>
     </form>
-@if (Route::has('register'))
-    <div class="space-x-1 text-center text-sm text-zinc-600 dark:text-zinc-400">
-        Don't have an account?
-        <flux:link href="{{ route('register') }}" wire:navigate>Sign up</flux:link>
-    </div>
-@endif
+    @if (Route::has('register'))
+        <div class="space-x-1 text-center text-sm text-zinc-600 dark:text-zinc-400">
+            Don't have an account?
+            <flux:link href="{{ route('register') }}" wire:navigate>Sign up</flux:link>
+        </div>
+    @endif
 </div>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -3,6 +3,7 @@
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;


### PR DESCRIPTION
When the register route has been disabled (to stop random signups) you then can't log in as the login form fails before it is rendered.

This PR fixes that.