### PR TITLE
Passes the title down to the head view

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,4 +1,4 @@
-<x-layouts.app.sidebar>
+<x-layouts.app.sidebar :title="$title ?? null">
     <flux:main>
         {{ $slot }}
     </flux:main>

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
     <head>
-        @include('partials.head')
+        @include('partials.head', ['title' => $title ?? null])
     </head>
     <body class="min-h-screen bg-white dark:bg-zinc-800">
         <flux:sidebar sticky stashable class="border-r border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
     <head>
-        @include('partials.head', ['title' => $title ?? null])
+        @include('partials.head')
     </head>
     <body class="min-h-screen bg-white dark:bg-zinc-800">
         <flux:sidebar sticky stashable class="border-r border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,4 +1,4 @@
-<x-layouts.app>
+<x-layouts.app title="Dashboard">
     <div class="flex h-full w-full flex-1 flex-col gap-4 rounded-xl">
         <div class="grid auto-rows-min gap-4 md:grid-cols-3">
             <div class="relative aspect-video overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">


### PR DESCRIPTION
# Changes

Adds `title` prop to `dashboard` view, `components.layout.app` & `components.layout.app.sidebar` which then sets the title variable in `partials.head`.

# Why

It's a bit confusing on first use how to set the title of the page. At the moment it just displays 'Laravel' and is hardcoded. With this it makes it the dashboard's title 'Dashboard' so that users can quickly resolve it.