### PR TITLE
Redirect to intended URL after registration

### DIFF
--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -31,7 +31,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         Auth::login($user);
 
-        $this->redirect(route('dashboard', absolute: false), navigate: true);
+        $this->redirectIntended(route('dashboard', absolute: false), navigate: true);
     }
 }; ?>
 


### PR DESCRIPTION
Currently, if a user attempts to access an authentication-protected resource without being logged in, they are redirected to the login page. After logging in, they are correctly redirected to the intended URL.

However, if the user doesn’t have an account and chooses to sign up instead, they are redirected to the dashboard route after registration, rather than the URL they initially intended to visit. This results in an inconsistent user experience, requiring manual navigation to the desired page after signing up.

This PR updates the registration component to ensure that users are redirected to their intended URL after completing the sign-up process.