### PR TITLE
Removes unused `flux:input` attributes

### DIFF
--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -45,10 +45,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <!-- Password -->
         <flux:input
             wire:model="password"
-            id="password"
             :label="__('Password')"
             type="password"
-            name="password"
             required
             autocomplete="new-password"
             placeholder="Password"

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -34,7 +34,6 @@ new #[Layout('components.layouts.auth')] class extends Component {
             wire:model="email"
             :label="__('Email Address')"
             type="email"
-            name="email"
             required
             autofocus
             placeholder="email@example.com"

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -85,7 +85,6 @@ new #[Layout('components.layouts.auth')] class extends Component {
             wire:model="email"
             :label="__('Email address')"
             type="email"
-            name="email"
             required
             autofocus
             autocomplete="email"
@@ -98,7 +97,6 @@ new #[Layout('components.layouts.auth')] class extends Component {
                 wire:model="password"
                 :label="__('Password')"
                 type="password"
-                name="password"
                 required
                 autocomplete="current-password"
                 placeholder="Password"

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -45,10 +45,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <!-- Name -->
         <flux:input
             wire:model="name"
-            id="name"
             :label="__('Name')"
             type="text"
-            name="name"
             required
             autofocus
             autocomplete="name"
@@ -58,10 +56,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <!-- Email Address -->
         <flux:input
             wire:model="email"
-            id="email"
             :label="__('Email address')"
             type="email"
-            name="email"
             required
             autocomplete="email"
             placeholder="email@example.com"
@@ -70,10 +66,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <!-- Password -->
         <flux:input
             wire:model="password"
-            id="password"
             :label="__('Password')"
             type="password"
-            name="password"
             required
             autocomplete="new-password"
             placeholder="Password"
@@ -82,10 +76,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <!-- Confirm Password -->
         <flux:input
             wire:model="password_confirmation"
-            id="password_confirmation"
             :label="__('Confirm password')"
             type="password"
-            name="password_confirmation"
             required
             autocomplete="new-password"
             placeholder="Confirm password"

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -78,10 +78,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <!-- Email Address -->
         <flux:input
             wire:model="email"
-            id="email"
             :label="__('Email')"
             type="email"
-            name="email"
             required
             autocomplete="email"
         />
@@ -89,10 +87,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <!-- Password -->
         <flux:input
             wire:model="password"
-            id="password"
             :label="__('Password')"
             type="password"
-            name="password"
             required
             autocomplete="new-password"
             placeholder="Password"
@@ -101,10 +97,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
         <!-- Confirm Password -->
         <flux:input
             wire:model="password_confirmation"
-            id="password_confirmation"
             :label="__('Confirm password')"
             type="password"
-            name="password_confirmation"
             required
             autocomplete="new-password"
             placeholder="Confirm password"

--- a/resources/views/livewire/settings/delete-user-form.blade.php
+++ b/resources/views/livewire/settings/delete-user-form.blade.php
@@ -44,7 +44,7 @@ new class extends Component {
                 </flux:subheading>
             </div>
 
-            <flux:input wire:model="password" id="password" :label="__('Password')" type="password" name="password" />
+            <flux:input wire:model="password" :label="__('Password')" type="password" />
 
             <div class="flex justify-end space-x-2">
                 <flux:modal.close>

--- a/resources/views/livewire/settings/password.blade.php
+++ b/resources/views/livewire/settings/password.blade.php
@@ -44,28 +44,22 @@ new class extends Component {
         <form wire:submit="updatePassword" class="mt-6 space-y-6">
             <flux:input
                 wire:model="current_password"
-                id="update_password_current_passwordpassword"
                 :label="__('Current password')"
                 type="password"
-                name="current_password"
                 required
                 autocomplete="current-password"
             />
             <flux:input
                 wire:model="password"
-                id="update_password_password"
                 :label="__('New password')"
                 type="password"
-                name="password"
                 required
                 autocomplete="new-password"
             />
             <flux:input
                 wire:model="password_confirmation"
-                id="update_password_password_confirmation"
                 :label="__('Confirm Password')"
                 type="password"
-                name="password_confirmation"
                 required
                 autocomplete="new-password"
             />

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -74,10 +74,10 @@ new class extends Component {
 
     <x-settings.layout :heading="__('Profile')" :subheading="__('Update your name and email address')">
         <form wire:submit="updateProfileInformation" class="my-6 w-full space-y-6">
-            <flux:input wire:model="name" :label="__('Name')" type="text" name="name" required autofocus autocomplete="name" />
+            <flux:input wire:model="name" :label="__('Name')" type="text" required autofocus autocomplete="name" />
 
             <div>
-                <flux:input wire:model="email" :label="__('Email')" type="email" name="email" required autocomplete="email" />
+                <flux:input wire:model="email" :label="__('Email')" type="email" required autocomplete="email" />
 
                 @if (auth()->user() instanceof \Illuminate\Contracts\Auth\MustVerifyEmail &&! auth()->user()->hasVerifiedEmail())
                     <div>


### PR DESCRIPTION
Removes attributes on the `flux:input` component which are not used, like `id` and `name`.

This makes the code more readable and easier to maintain.