### PR TITLE
fix: pass title variable on layout components

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,4 +1,4 @@
-<x-layouts.app.sidebar>
+<x-layouts.app.sidebar :title="$title ?? null">
     <flux:main>
         {{ $slot }}
     </flux:main>

--- a/resources/views/components/layouts/auth.blade.php
+++ b/resources/views/components/layouts/auth.blade.php
@@ -1,3 +1,3 @@
-<x-layouts.auth.simple>
+<x-layouts.auth.simple :title="$title ?? null">
     {{ $slot }}
 </x-layouts.auth.simple>


### PR DESCRIPTION
Makes sure that when we use the ``#[Title(...)]`` attribute to our Livewire components to always set the given value, otherwise it should fallback to the default preset title in ``partials.head``

Reference: https://github.com/livewire/livewire/discussions/9212#discussioncomment-12371486