### PR TITLE
Add missing translations

### DIFF
--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -1,7 +1,7 @@
 <div class="flex flex-col gap-6">
     <x-auth-header
-        title="Confirm password"
-        description="This is a secure area of the application. Please confirm your password before continuing."
+        title="{{ __('Confirm password') }}"
+        description="{{ __('This is a secure area of the application. Please confirm your password before continuing.') }}"
     />
 
     <!-- Session Status -->
@@ -17,7 +17,7 @@
             name="password"
             required
             autocomplete="new-password"
-            placeholder="Password"
+            placeholder="{{ __('Password') }}"
         />
 
         <flux:button variant="primary" type="submit" class="w-full">{{ __('Confirm') }}</flux:button>

--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -1,7 +1,7 @@
 <div class="flex flex-col gap-6">
     <x-auth-header
-        title="{{ __('Confirm password') }}"
-        description="{{ __('This is a secure area of the application. Please confirm your password before continuing.') }}"
+        :title="__('Confirm password')"
+        :description="__('This is a secure area of the application. Please confirm your password before continuing.')"
     />
 
     <!-- Session Status -->
@@ -17,7 +17,7 @@
             name="password"
             required
             autocomplete="new-password"
-            placeholder="{{ __('Password') }}"
+            :placeholder="__('Password')"
         />
 
         <flux:button variant="primary" type="submit" class="w-full">{{ __('Confirm') }}</flux:button>

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -1,5 +1,5 @@
  <div class="flex flex-col gap-6">
-    <x-auth-header title="{{ __('Forgot password') }}" description="{{ __('Enter your email to receive a password reset link') }}" />
+    <x-auth-header :title="__('Forgot password')" :description="__('Enter your email to receive a password reset link')" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -1,5 +1,5 @@
  <div class="flex flex-col gap-6">
-    <x-auth-header title="Forgot password" description="Enter your email to receive a password reset link" />
+    <x-auth-header title="{{ __('Forgot password') }}" description="{{ __('Enter your email to receive a password reset link') }}" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -20,7 +20,7 @@
     </form>
 
     <div class="space-x-1 text-center text-sm text-zinc-400">
-        Or, return to
-        <flux:link :href="route('login')" wire:navigate>log in</flux:link>
+        {{ __('Or, return to') }}
+        <flux:link :href="route('login')" wire:navigate>{{ __('log in') }}</flux:link>
     </div>
 </div>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -1,5 +1,5 @@
 <div class="flex flex-col gap-6">
-    <x-auth-header title="Log in to your account" description="Enter your email and password below to log in" />
+    <x-auth-header title="{{ __('Log in to your account') }}" description="{{ __('Enter your email and password below to log in') }}" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -26,7 +26,7 @@
                 name="password"
                 required
                 autocomplete="current-password"
-                placeholder="Password"
+                placeholder="{{ __('Password') }}"
             />
 
             @if (Route::has('password.request'))
@@ -46,8 +46,8 @@
 
     @if (Route::has('register'))
       <div class="space-x-1 text-center text-sm text-zinc-600 dark:text-zinc-400">
-          Don't have an account?
-          <flux:link :href="route('register')" wire:navigate>Sign up</flux:link>
+          {{ __("Don't have an account?") }}
+          <flux:link :href="route('register')" wire:navigate>{{ __("Sign up") }}</flux:link>
       </div>
     @endif
 </div>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -26,7 +26,7 @@
                 name="password"
                 required
                 autocomplete="current-password"
-                placeholder="{{ __('Password') }}"
+                :placeholder="__('Password')"
             />
 
             @if (Route::has('password.request'))

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -1,5 +1,5 @@
 <div class="flex flex-col gap-6">
-    <x-auth-header title="{{ __('Create an account') }}" description="{{ __('Enter your details below to create your account') }}" />
+    <x-auth-header :title="__('Create an account')" :description="__('Enter your details below to create your account')" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -15,7 +15,7 @@
             required
             autofocus
             autocomplete="name"
-            placeholder="{{ __('Full name') }}"
+            :placeholder="__('Full name')"
         />
 
         <!-- Email Address -->
@@ -39,7 +39,7 @@
             name="password"
             required
             autocomplete="new-password"
-            placeholder="{{ __('Password') }}"
+            :placeholder="__('Password')"
         />
 
         <!-- Confirm Password -->
@@ -51,7 +51,7 @@
             name="password_confirmation"
             required
             autocomplete="new-password"
-            placeholder="{{ __('Confirm password') }}"
+            :placeholder="__('Confirm password')"
         />
 
         <div class="flex items-center justify-end">

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -1,5 +1,5 @@
 <div class="flex flex-col gap-6">
-    <x-auth-header title="Create an account" description="Enter your details below to create your account" />
+    <x-auth-header title="{{ __('Create an account') }}" description="{{ __('Enter your details below to create your account') }}" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -15,7 +15,7 @@
             required
             autofocus
             autocomplete="name"
-            placeholder="Full name"
+            placeholder="{{ __('Full name') }}"
         />
 
         <!-- Email Address -->
@@ -39,7 +39,7 @@
             name="password"
             required
             autocomplete="new-password"
-            placeholder="Password"
+            placeholder="{{ __('Password') }}"
         />
 
         <!-- Confirm Password -->
@@ -51,7 +51,7 @@
             name="password_confirmation"
             required
             autocomplete="new-password"
-            placeholder="Confirm password"
+            placeholder="{{ __('Confirm password') }}"
         />
 
         <div class="flex items-center justify-end">
@@ -62,7 +62,7 @@
     </form>
 
     <div class="space-x-1 text-center text-sm text-zinc-600 dark:text-zinc-400">
-        Already have an account?
-        <flux:link :href="route('login')" wire:navigate>Log in</flux:link>
+        {{ __('Already have an account?') }}
+        <flux:link :href="route('login')" wire:navigate>{{ __('Log in') }}</flux:link>
     </div>
 </div>

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -1,5 +1,5 @@
 <div class="flex flex-col gap-6">
-    <x-auth-header title="Reset password" description="Please enter your new password below" />
+    <x-auth-header title="{{ __('Reset password') }}" description="{{ __('Please enter your new password below') }}" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -25,7 +25,7 @@
             name="password"
             required
             autocomplete="new-password"
-            placeholder="Password"
+            placeholder="{{ __('Password') }}"
         />
 
         <!-- Confirm Password -->
@@ -37,7 +37,7 @@
             name="password_confirmation"
             required
             autocomplete="new-password"
-            placeholder="Confirm password"
+            placeholder="{{ __('Confirm password') }}"
         />
 
         <div class="flex items-center justify-end">

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -1,5 +1,5 @@
 <div class="flex flex-col gap-6">
-    <x-auth-header title="{{ __('Reset password') }}" description="{{ __('Please enter your new password below') }}" />
+    <x-auth-header :title="__('Reset password')" :description="__('Please enter your new password below')" />
 
     <!-- Session Status -->
     <x-auth-session-status class="text-center" :status="session('status')" />
@@ -25,7 +25,7 @@
             name="password"
             required
             autocomplete="new-password"
-            placeholder="{{ __('Password') }}"
+            :placeholder="__('Password')"
         />
 
         <!-- Confirm Password -->
@@ -37,7 +37,7 @@
             name="password_confirmation"
             required
             autocomplete="new-password"
-            placeholder="{{ __('Confirm password') }}"
+            :placeholder="__('Confirm password')"
         />
 
         <div class="flex items-center justify-end">

--- a/resources/views/partials/settings-heading.blade.php
+++ b/resources/views/partials/settings-heading.blade.php
@@ -1,5 +1,5 @@
 <div class="relative mb-6 w-full">
-    <flux:heading size="xl" level="1">Settings</flux:heading>
+    <flux:heading size="xl" level="1">{{ __('Settings') }}</flux:heading>
     <flux:subheading size="lg" class="mb-6">{{ __('Manage your profile and account settings') }}</flux:subheading>
     <flux:separator variant="subtle" />
 </div>


### PR DESCRIPTION
This PR wraps static text strings in starter kit with the __() helper to enable proper translation support in areas where it was missing.