### PR TITLE
fix: Commit step -- replace file_pattern expression

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,4 +41,6 @@ jobs:
       #   with:
       #     commit_message: fix code style
       #     commit_options: '--no-verify'
-      #     file_pattern: '!.github/workflows/* **/*'
+      #     file_pattern: |
+      #       **/*
+      #       !.github/workflows/*


### PR DESCRIPTION
I’ve been trying to use the ‘Commit Changes’ step from the Lint Action, but it always fails when I run it. 

I’ve attached a change suggestion that should fix this issue.