### PR TITLE
Fix test `users_can_not_authenticate_with_invalid_password`

### DIFF
--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -44,6 +44,7 @@ class AuthenticationTest extends TestCase
             ->call('login');
 
         $response->assertHasErrors('email');
+
         $this->assertGuest();
     }
 

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -38,11 +38,12 @@ class AuthenticationTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $this->post('/login', [
-            'email' => $user->email,
-            'password' => 'wrong-password',
-        ]);
+        $response = LivewireVolt::test('auth.login')
+            ->set('email', $user->email)
+            ->set('password', 'wrong-password')
+            ->call('login');
 
+        $response->assertHasErrors('email');
         $this->assertGuest();
     }
 


### PR DESCRIPTION
The post `/login` path does not exist, currently this test is reporting a 405 Method Not Allowed error.

Modified to test the actual code within the Livewire component.

I saw this issue because I copied this test in order to create one hitting the rate limiter, and it was not working. 😅

----

The non Volt version has the same issue, I'll make a PR to that branch too.