### PR TITLE
Fix test `users_can_not_authenticate_with_invalid_password` (Components branch)

### DIFF
--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -39,11 +39,12 @@ class AuthenticationTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $this->post('/login', [
-            'email' => $user->email,
-            'password' => 'wrong-password',
-        ]);
+        $response = Livewire::test(Login::class)
+            ->set('email', $user->email)
+            ->set('password', 'wrong-password')
+            ->call('login');
 
+        $response->assertHasErrors('email');
         $this->assertGuest();
     }
 

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -45,6 +45,7 @@ class AuthenticationTest extends TestCase
             ->call('login');
 
         $response->assertHasErrors('email');
+
         $this->assertGuest();
     }
 
@@ -54,7 +55,8 @@ class AuthenticationTest extends TestCase
 
         $response = $this->actingAs($user)->post('/logout');
 
-        $this->assertGuest();
         $response->assertRedirect('/');
+
+        $this->assertGuest();
     }
 }


### PR DESCRIPTION
Same as #64 targeting `components` branch.