### PR TITLE
Add RedirectResponse return type to Logout action

### DIFF
--- a/app/Livewire/Actions/Logout.php
+++ b/app/Livewire/Actions/Logout.php
@@ -5,13 +5,14 @@ namespace App\Livewire\Actions;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
+use Livewire\Features\SupportRedirects\Redirector;
 
 class Logout
 {
     /**
      * Log the current user out of the application.
      */
-    public function __invoke(): RedirectResponse
+    public function __invoke(): RedirectResponse|Redirector
     {
         Auth::guard('web')->logout();
 

--- a/app/Livewire/Actions/Logout.php
+++ b/app/Livewire/Actions/Logout.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Actions;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 
@@ -10,7 +11,7 @@ class Logout
     /**
      * Log the current user out of the application.
      */
-    public function __invoke()
+    public function __invoke(): RedirectResponse
     {
         Auth::guard('web')->logout();
 


### PR DESCRIPTION
This pull request adds the correct return type declaration to the Logout action's `__invoke()` method. The method needs a union type of `RedirectResponse|Redirector` to properly type-hint the return value of the `redirect()` helper function.

I found that using only `RedirectResponse` or only `Redirector` as the return type wasn't sufficient to satisfy both tests and static analysis. The Laravel `redirect()` helper can return either type depending on the context. This union type solution ensures correct type checking while maintaining compatibility with Laravel's actual behavior.