### PR TITLE
Update README to describe configuration variant working trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ Our Laravel + [Livewire](https://livewire.laravel.com) starter kit provides a ro
 
 Livewire is a powerful way of building dynamic, reactive, frontend UIs using just PHP. It's a great fit for teams that primarily use Blade templates and are looking for a simpler alternative to JavaScript-driven SPA frameworks like React and Vue.
 
-This Livewire starter kit utilizes Livewire 3, Laravel Volt, TypeScript, Tailwind, and the [Flux UI](https://fluxui.dev) component library.
+This Livewire starter kit utilizes Livewire 3, Laravel Volt (optionally), TypeScript, Tailwind, and the [Flux UI](https://fluxui.dev) component library.
+
+If you are looking for the alternate configurations of this Starter Kit, they can be found in the following branches:
+
+- [components](https://github.com/laravel/livewire-starter-kit/tree/components) - if Volt is not selected
+- [workos](https://github.com/laravel/livewire-starter-kit/tree/workos) - if WorkOS is selected for Authentication
 
 ## Official Documentation
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Livewire is a powerful way of building dynamic, reactive, frontend UIs using jus
 
 This Livewire starter kit utilizes Livewire 3, Laravel Volt (optionally), TypeScript, Tailwind, and the [Flux UI](https://fluxui.dev) component library.
 
-If you are looking for the alternate configurations of this Starter Kit, they can be found in the following branches:
+If you are looking for the alternate configurations of this starter kit, they can be found in the following branches:
 
 - [components](https://github.com/laravel/livewire-starter-kit/tree/components) - if Volt is not selected
-- [workos](https://github.com/laravel/livewire-starter-kit/tree/workos) - if WorkOS is selected for Authentication
+- [workos](https://github.com/laravel/livewire-starter-kit/tree/workos) - if WorkOS is selected for authentication
 
 ## Official Documentation
 


### PR DESCRIPTION
Hi,

I wanted to contribute some changes to this Starter Kit, but realized I was looking at the `main` branch's Volt-specific code. I had decided not to use Volt locally, so my code looked different.  It took some digging to figure out that the alternate configurations are just different branches on this repo. Makes sense, but hard to find unless you know where to look.  This may also help contributors understand that they may want to fork the entire repo rather than just `main`.

Hope this helps, and if you have any stylistic feedback or other info to add, feel free to edit.  I hope this sort of thing can be published rather than obfuscated.