### PR TITLE
Allow login and registration with capitalized emails

### DIFF
--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -12,9 +12,11 @@ new #[Layout('components.layouts.auth')] class extends Component {
      */
     public function sendPasswordResetLink(): void
     {
-        $this->validate([
+        $validated = $this->validate([
             'email' => ['required', 'string', 'email'],
         ]);
+
+        $validated['email'] = strtolower($validated['email']);
 
         Password::sendResetLink($this->only('email'));
 

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -12,12 +12,10 @@ new #[Layout('components.layouts.auth')] class extends Component {
      */
     public function sendPasswordResetLink(): void
     {
-        $validated = $this->validate([
+        $this->validate([
             'email' => ['required', 'string', 'email'],
         ]);
-
-        $validated['email'] = strtolower($validated['email']);
-
+        $this->email = mb_strtolower($this->email);
         Password::sendResetLink($this->only('email'));
 
         session()->flash('status', __('A reset link will be sent if the account exists.'));

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
@@ -15,7 +16,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         $this->validate([
             'email' => ['required', 'string', 'email'],
         ]);
-        $this->email = mb_strtolower($this->email);
+        $this->email = Str::lower($this->email);
         Password::sendResetLink($this->only('email'));
 
         session()->flash('status', __('A reset link will be sent if the account exists.'));

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -29,7 +29,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt(['email' => mb_strtolower($this->email), 'password' => $this->password], $this->remember)) {
+        if (! Auth::attempt(['email' => Str::lower($this->email), 'password' => $this->password], $this->remember)) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -29,7 +29,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt(['email' => strtolower($this->email), 'password' => $this->password], $this->remember)) {
+        if (! Auth::attempt(['email' => mb_strtolower($this->email), 'password' => $this->password], $this->remember)) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -29,7 +29,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt(['email' => $this->email, 'password' => $this->password], $this->remember)) {
+        if (! Auth::attempt(['email' => strtolower($this->email), 'password' => $this->password], $this->remember)) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -25,7 +25,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
         ]);
 
-        $validated['email'] = strtolower($validated['email']);
+        $validated['email'] = mb_strtolower($validated['email']);
         $validated['password'] = Hash::make($validated['password']);
 
         event(new Registered(($user = User::create($validated))));

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -4,6 +4,7 @@ use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rules;
 use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
@@ -25,7 +26,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
         ]);
 
-        $validated['email'] = mb_strtolower($validated['email']);
+        $validated['email'] = Str::lower($validated['email']);
         $validated['password'] = Hash::make($validated['password']);
 
         event(new Registered(($user = User::create($validated))));

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -21,10 +21,11 @@ new #[Layout('components.layouts.auth')] class extends Component {
     {
         $validated = $this->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:' . User::class],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:' . User::class],
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
         ]);
 
+        $validated['email'] = strtolower($validated['email']);
         $validated['password'] = Hash::make($validated['password']);
 
         event(new Registered(($user = User::create($validated))));

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -24,7 +24,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     {
         $this->token = $token;
 
-        $this->email = strtolower(request()->string('email'));
+        $this->email = mb_strtolower(request()->string('email'));
     }
 
     /**
@@ -37,14 +37,13 @@ new #[Layout('components.layouts.auth')] class extends Component {
             'email' => ['required', 'string', 'email'],
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
         ]);
-
-        $validated['email'] = strtolower($validated['email']);
+        $validated['email'] = mb_strtolower($validated['email']);
 
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
         $status = Password::reset(
-            $this->only('email', 'password', 'password_confirmation', 'token'),
+            $this->only($validated['email'], 'password', 'password_confirmation', 'token'),
             function ($user) {
                 $user->forceFill([
                     'password' => Hash::make($this->password),

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -24,7 +24,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     {
         $this->token = $token;
 
-        $this->email = mb_strtolower(request()->string('email'));
+        $this->email = Str::lower(request()->string('email'));
     }
 
     /**
@@ -32,18 +32,18 @@ new #[Layout('components.layouts.auth')] class extends Component {
      */
     public function resetPassword(): void
     {
-        $validated = $this->validate([
+        $this->validate([
             'token' => ['required'],
             'email' => ['required', 'string', 'email'],
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
         ]);
-        $validated['email'] = mb_strtolower($validated['email']);
+        $this->email = Str::lower($this->email);
 
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
         $status = Password::reset(
-            $this->only($validated['email'], 'password', 'password_confirmation', 'token'),
+            $this->only('email', 'password', 'password_confirmation', 'token'),
             function ($user) {
                 $user->forceFill([
                     'password' => Hash::make($this->password),

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -24,7 +24,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     {
         $this->token = $token;
 
-        $this->email = request()->string('email');
+        $this->email = strtolower(request()->string('email'));
     }
 
     /**
@@ -32,11 +32,13 @@ new #[Layout('components.layouts.auth')] class extends Component {
      */
     public function resetPassword(): void
     {
-        $this->validate([
+        $validated = $this->validate([
             'token' => ['required'],
             'email' => ['required', 'string', 'email'],
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
         ]);
+
+        $validated['email'] = strtolower($validated['email']);
 
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Auth;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Livewire\Volt\Volt as LivewireVolt;
 use Tests\TestCase;
 
@@ -47,6 +48,26 @@ class AuthenticationTest extends TestCase
 
         $this->assertGuest();
     }
+
+    public function test_user_can_authenticate_with_uppercase_email(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'user@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $response = LivewireVolt::test('auth.login')
+            ->set('email', Str::upper($user->email)) // USER@EXAMPLE.COM
+            ->set('password', 'password')
+            ->call('login');
+
+        $response
+            ->assertHasNoErrors()
+            ->assertRedirect(route('dashboard', absolute: false));
+
+        $this->assertAuthenticatedAs($user);
+    }
+
 
     public function test_users_can_logout(): void
     {

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Auth;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Livewire\Volt\Volt;
 use Tests\TestCase;
 
@@ -32,4 +33,27 @@ class RegistrationTest extends TestCase
 
         $this->assertAuthenticated();
     }
+
+    public function test_new_user_email_is_stored_as_lowercase_even_if_input_is_uppercase(): void
+    {
+        $uppercaseEmail = 'TEST@EXAMPLE.COM';
+
+        $response = Volt::test('auth.register')
+            ->set('name', 'Test User')
+            ->set('email', $uppercaseEmail)
+            ->set('password', 'password')
+            ->set('password_confirmation', 'password')
+            ->call('register');
+
+        $response
+            ->assertHasNoErrors()
+            ->assertRedirect(route('dashboard', absolute: false));
+
+        $this->assertAuthenticated();
+
+        $this->assertDatabaseHas('users', [
+            'email' => Str::lower($uppercaseEmail),
+        ]);
+    }
+
 }


### PR DESCRIPTION
This PR adds support for users to register and log in using email addresses with capital letters (e.g. John.Doe@Example.COM). Internally, all email addresses are automatically converted to lowercase to ensure consistent handling and avoid duplicate accounts due to case differences.

What’s changed:
During registration, the provided email is converted to lowercase before being saved.

During login, the input email is also lowercased before attempting authentication.

Improves user experience and reduces confusion related to email case sensitivity.

This update is fully backward-compatible and does not affect existing accounts.