### PR TITLE
Adding default hot reloading/refreshing back to the vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.js'],
-            refresh: [`resources/views/**/*`],
+            refresh: true,
         }),
         tailwindcss(),
     ],


### PR DESCRIPTION
This PR will add the default refresh directories back to the Livewire Starter kit.

This will revert the defaults for a Livewire application and will watch for changes in the following directories:

```
'app/Livewire/**',
'app/View/Components/**',
'lang/**',
'resources/lang/**',
'resources/views/**',
'routes/**',
```