### PR TITLE
Makes flux password inputs viewable

### DIFF
--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -50,6 +50,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             required
             autocomplete="new-password"
             :placeholder="__('Password')"
+            viewable
         />
 
         <flux:button variant="primary" type="submit" class="w-full">{{ __('Confirm') }}</flux:button>

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -37,6 +37,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             required
             autofocus
             placeholder="email@example.com"
+            viewable
         />
 
         <flux:button variant="primary" type="submit" class="w-full">{{ __('Email password reset link') }}</flux:button>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -100,6 +100,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
                 required
                 autocomplete="current-password"
                 :placeholder="__('Password')"
+                viewable
             />
 
             @if (Route::has('password.request'))

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -71,6 +71,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             required
             autocomplete="new-password"
             :placeholder="__('Password')"
+            viewable
         />
 
         <!-- Confirm Password -->
@@ -81,6 +82,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             required
             autocomplete="new-password"
             :placeholder="__('Confirm password')"
+            viewable
         />
 
         <div class="flex items-center justify-end">

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -92,6 +92,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             required
             autocomplete="new-password"
             :placeholder="__('Password')"
+            viewable
         />
 
         <!-- Confirm Password -->
@@ -102,6 +103,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             required
             autocomplete="new-password"
             :placeholder="__('Confirm password')"
+            viewable
         />
 
         <div class="flex items-center justify-end">


### PR DESCRIPTION
Flux allows you to make password inputs viewable (by clicking a little eyeball icon) by simply adding a `viewable` attribute, which is pretty amazing when you think about it! This PR adds the `viewable` attribute to the flux password inputs.

https://fluxui.dev/components/input#clearable-copyable-and-viewable-inputs