### PR TITLE
Making sure all related processed are closed when terminating the currently command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
         ],
         "test": [
             "@php artisan config:clear --ansi",


### PR DESCRIPTION
# Context

When running `composer run dev`, the [concurrently](https://www.npmjs.com/package/concurrently) package is used to start multiple processes in one terminal. This is a great addition to the Laravel starter kits! However, when sending the EXIT signal (CTRL + C) only the last process in the configured list is closed. 

# Resolution

By adding the **--kill-others** option to the command, **all** the related processes are closed.

I would add this flag in by default, as the current behaviour is most likely unintended. For example, in case you are switching projects and need the ports released for re-use, you now need to manually find the other processes and close them yourself.

# Disclaimer

This change was already approved in the Vue starter kit: https://github.com/laravel/vue-starter-kit/pull/123