### PR TITLE
Only show desktop user menu in lg screen width

### DIFF
--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -30,7 +30,7 @@
             </flux:navlist>
 
             <!-- Desktop User Menu -->
-            <flux:dropdown position="bottom" align="start">
+            <flux:dropdown class="hidden lg:block" position="bottom" align="start">
                 <flux:profile
                     :name="auth()->user()->name"
                     :initials="auth()->user()->initials()"


### PR DESCRIPTION
Fixing the desktop vs. mobile user menu showing up in the dashboard. The "Desktop User Menu" should not show up unless the screen size is large or greater.

Before:
https://github.com/user-attachments/assets/8d2178a5-b884-4c9d-8446-42e023aff78a

After:
https://github.com/user-attachments/assets/e39b53ed-e1b6-465a-86ed-cd59b57a2d8a

