### PR TITLE
Fix: Convert Stringable to string for email property

### DIFF
--- a/app/Livewire/Auth/ResetPassword.php
+++ b/app/Livewire/Auth/ResetPassword.php
@@ -31,7 +31,7 @@ class ResetPassword extends Component
     {
         $this->token = $token;
 
-        $this->email = request()->string('email');
+        $this->email = request()->string('email')->value();
     }
 
     /**


### PR DESCRIPTION
The `request()->string('email')` method returns an `Illuminate\Support\Stringable` object, which causes a TypeError `Cannot assign Illuminate\Support\Stringable to property App\Livewire\Auth\ResetPassword::$email of type string` when using `declare(strict_types=1)`, which most of us (presumably) use.

Added `->value()` to convert the Stringable object to a plain string value.