### PR TITLE
Fix 'chevrons-up-down' in sidebar.blade.php

### DIFF
--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -84,7 +84,7 @@
             <flux:dropdown position="top" align="end">
                 <flux:profile
                     :initials="auth()->user()->initials()"
-                    icon-trailing="chevron-down"
+                    icon:trailing="chevron-down"
                 />
 
                 <flux:menu>


### PR DESCRIPTION
Because of accepted [PR #98](https://github.com/laravel/livewire-starter-kit/pull/98) and this PR (if accepted) an included with Flux '[chevron-up-down](https://github.com/livewire/flux/blob/main/stubs/resources/views/flux/icon/chevron-up-down.blade.php)' component will be used (even though it's called 'custom'), which looks visually the same as the current 'chevrons-up-down', I checked this.

So, I suppose, the currently used ['chevrons-up-down'](https://github.com/laravel/livewire-starter-kit/blob/main/resources/views/flux/icon/chevrons-up-down.blade.php) icon/component **is not needed anymore and can be removed** from the current livewire-starter-kit version. 

See [https://fluxui.dev/components/profile#custom-trailing-icon](https://fluxui.dev/components/profile#custom-trailing-icon)