### PR TITLE
chore(views): remove redundant `viewable` attribute from email input

### DIFF
--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -37,7 +37,6 @@ new #[Layout('components.layouts.auth')] class extends Component {
             required
             autofocus
             placeholder="email@example.com"
-            viewable
         />
 
         <flux:button variant="primary" type="submit" class="w-full">{{ __('Email password reset link') }}</flux:button>


### PR DESCRIPTION
There is a "viewable" attribute on the email input which is redundant as the field type isn't password. This removes that attribute.