### PR TITLE
chore: use app.name config for dashboard header

### DIFF
--- a/resources/views/components/app-logo.blade.php
+++ b/resources/views/components/app-logo.blade.php
@@ -2,5 +2,5 @@
     <x-app-logo-icon class="size-5 fill-current text-white dark:text-black" />
 </div>
 <div class="ms-1 grid flex-1 text-start text-sm">
-    <span class="mb-0.5 truncate leading-tight font-semibold">Laravel Starter Kit</span>
+    <span class="mb-0.5 truncate leading-tight font-semibold">{{ config('app.name') }}</span>
 </div>


### PR DESCRIPTION
Just a minor change. I always forget to update this. Most things already use `config('app.name')` so I thought it might be nice if we swapped this out with the config value instead of `Laravel Starter Kit`.