### PR TITLE
Add data-test attribute to sidebar menu button for testing

### DIFF
--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -35,6 +35,7 @@
                     :name="auth()->user()->name"
                     :initials="auth()->user()->initials()"
                     icon:trailing="chevrons-up-down"
+                    data-test="sidebar-menu-button"
                 />
 
                 <flux:menu class="w-[220px]">


### PR DESCRIPTION
This MR fix the flaky logout test by adding the `data-test` attribute on the sidebar menu button for more reliable testing.