### PR TITLE
Redirect to intended route

### DIFF
--- a/routes/auth.php
+++ b/routes/auth.php
@@ -10,7 +10,7 @@ Route::get('login', function (AuthKitLoginRequest $request) {
 })->middleware(['guest'])->name('login');
 
 Route::get('authenticate', function (AuthKitAuthenticationRequest $request) {
-    return tap(to_route('dashboard'), fn () => $request->authenticate());
+    return tap(redirect()->intended(route('dashboard')), fn () => $request->authenticate());
 })->middleware(['guest']);
 
 Route::post('logout', function (AuthKitLogoutRequest $request) {


### PR DESCRIPTION
When you visit for instance `/settings/profile` and have to login along the way, you will get sent to the dashboard after some workos flows. This change sends you to the intended route, then falls back to the dashboard if there isn't any.