### PR TITLE
Improve QR code readability in dark mode by adding white background and padding

### DIFF
--- a/resources/views/livewire/settings/two-factor.blade.php
+++ b/resources/views/livewire/settings/two-factor.blade.php
@@ -311,7 +311,9 @@ new class extends Component {
                             </div>
                         @else
                             <div class="flex items-center justify-center h-full p-4">
-                                {!! $qrCodeSvg !!}
+                                <div class="bg-white p-3 rounded">
+                                    {!! $qrCodeSvg !!}
+                                </div>
                             </div>
                         @endempty
                     </div>


### PR DESCRIPTION
This update wraps the generated QR code in a white container with padding. 
The change ensures a clear quiet zone around the QR code, making it easier to scan, especially in dark mode where the background contrast was insufficient. 

- Added `bg-white p-3 rounded` to wrapper div
- Improves scan reliability across different themes
