### PR TITLE
Fix MissingAttributeException in TwoFactorAuthenticationTest

### DIFF
--- a/tests/Feature/Settings/TwoFactorAuthenticationTest.php
+++ b/tests/Feature/Settings/TwoFactorAuthenticationTest.php
@@ -30,7 +30,7 @@ class TwoFactorAuthenticationTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $this->actingAs($user)
+        $this->actingAs($user->refresh())
             ->withSession(['auth.password_confirmed_at' => time()])
             ->get(route('two-factor.show'))
             ->assertOk()


### PR DESCRIPTION
This PR resolves a failing test in TwoFactorAuthenticationTest.php when running with Model::shouldBeStrict() enabled.