### PR TITLE
Refactor the UserFactory to include withoutTwoFactor method

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,9 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'two_factor_secret' => Str::random(10),
+            'two_factor_recovery_codes' => Str::random(10),
+            'two_factor_confirmed_at' => now(),
         ];
     }
 
@@ -39,6 +42,18 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the model does not have two-factor authentication configured.
+     */
+    public function withoutTwoFactor(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'two_factor_secret' => null,
+            'two_factor_recovery_codes' => null,
+            'two_factor_confirmed_at' => null,
         ]);
     }
 }

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -21,7 +21,7 @@ class AuthenticationTest extends TestCase
 
     public function test_users_can_authenticate_using_the_login_screen(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->withoutTwoFactor()->create();
 
         $response = LivewireVolt::test('auth.login')
             ->set('email', $user->email)

--- a/tests/Feature/Settings/TwoFactorAuthenticationTest.php
+++ b/tests/Feature/Settings/TwoFactorAuthenticationTest.php
@@ -28,7 +28,7 @@ class TwoFactorAuthenticationTest extends TestCase
 
     public function test_two_factor_settings_page_can_be_rendered(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->withoutTwoFactor()->create();
 
         $this->actingAs($user)
             ->withSession(['auth.password_confirmed_at' => time()])


### PR DESCRIPTION
This PR resolves a failing test in TwoFactorAuthenticationTest.php when running with Model::shouldBeStrict() enabled because of unavailable attributes.